### PR TITLE
feat(cmd): add rename subcommand to update record aliases #22

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,11 @@ enum Commands {
         #[clap(flatten)]
         encryption: EncryptArgs,
     },
+    /// Rename alias
+    Rename {
+        old_alias: String,
+        new_alias: String,
+    },
     /// Get codes for all/alias records
     Ls {
         #[clap(short = 'a', long)]
@@ -113,6 +118,12 @@ fn run(args: Args, codex_path: PathBuf) -> Result<(), String> {
                 &encryption.unencrypt,
                 &encryption.password,
             );
+        }
+        Commands::Rename {
+            old_alias,
+            new_alias,
+        } => {
+            cmd::rename(&codex_path, old_alias.as_str(), new_alias.as_str())?;
         }
         Commands::Ls {
             alias,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -51,5 +52,13 @@ impl Record {
             });
         }
         None
+    }
+}
+
+impl fmt::Display for Record {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // serialize the current record to a JSON
+        let json = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        write!(f, "{}", json)
     }
 }


### PR DESCRIPTION
- Add `rename` subcommand to update aliase.
- Implement std::fmt::Display for Record struct using serde_json.