### PR TITLE
Bugfix: Removed trimming of data 

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -41,11 +41,12 @@ pub fn read_file_to_vec(path: &Path) -> io::Result<Vec<String>> {
 
 pub fn append_to_file(path: &Path, data: &str) -> io::Result<()> {
     let mut data_file = OpenOptions::new().append(true).open(path)?;
-    writeln!(data_file, "{}", data)
+    writeln!(data_file, "{}", data.trim())
 }
 
 pub fn overwrite_file(path: &Path, data: &str) -> io::Result<()> {
-    std::fs::write(path, data)
+    let line = String::from(data) + "\n";
+    std::fs::write(path, line)
 }
 
 pub fn alias_exists(alias: &str, path: &Path) -> bool {


### PR DESCRIPTION
Data being trimmed when written to the codex led to everything being written in the first line, breaking ls as a result. Removing trim seems to have fixed the bug

EDIT: Trimming wasn't the bug, we were just forgetting to switch lines when overwrite_file created a new file and inserted the first entry. 