### PR TITLE
feat(ls): add exact match filtering with --exact flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,6 @@ dependencies = [
  "dirs",
  "magic-crypt",
  "predicates",
- "rand",
  "rpassword",
  "serde",
  "serde_json",
@@ -513,15 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,35 +564,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "redox_users"
@@ -982,26 +943,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/src/args.rs
+++ b/src/args.rs
@@ -58,6 +58,8 @@ pub enum Commands {
         alias: Option<String>,
         #[clap(short, long)]
         quiet: bool,
+        #[clap(short, long)]
+        exact: bool,
         #[arg(short = 'f', long, value_enum, default_value_t = OutputFormat::Table)]
         format: OutputFormat,
         #[clap(flatten)]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -159,29 +159,45 @@ pub fn remove(path: &Path, alias: &str) -> Result<(), String> {
 pub fn ls(
     path: &Path,
     alias_filter: &Option<String>,
-    is_unencrypt: &bool,
+    is_unencrypt: bool,
     password: &Option<String>,
     format: &OutputFormat,
     quiet: bool,
+    exact_match: bool,
 ) -> Result<(), String> {
     let records = file::read_codex(path)?;
 
     // apply search filter
-    let filtered: Vec<&Record> = records
-        .iter()
-        .filter(|r| match alias_filter {
-            // partial match
-            Some(f) => r.alias.to_lowercase().contains(&f.to_lowercase()),
-            // display everything
-            None => true,
-        })
-        .collect();
+    let filtered: Vec<&Record> = if let Some(filter) = alias_filter {
+        let filter_lower = filter.to_lowercase();
+        records
+            .iter()
+            .filter(|r| {
+                let alias_lower = r.alias.to_lowercase();
+                if exact_match {
+                    alias_lower == filter_lower
+                } else {
+                    alias_lower.contains(&filter_lower)
+                }
+            })
+            .collect()
+    } else {
+        records.iter().collect()
+    };
 
     if filtered.is_empty() {
-        return Err("Alias not found.".into());
+        return Err(if let Some(filter) = alias_filter {
+            if exact_match {
+                format!("No record found with exact alias '{}'", filter)
+            } else {
+                format!("No records found matching '{}'", filter)
+            }
+        } else {
+            "No records found".into()
+        });
     }
 
-    let needs_password = !*is_unencrypt && filtered.iter().any(|r| !r.is_unencrypted);
+    let needs_password = !is_unencrypt && filtered.iter().any(|r| !r.is_unencrypted);
 
     let pass = if needs_password {
         get_effective_password(password)

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,14 +80,16 @@ fn run(command: Commands, codex_path: PathBuf) -> Result<(), String> {
             quiet,
             format,
             encryption,
+            exact,
         } => {
             cmd::ls(
                 &codex_path,
                 &alias,
-                &encryption.unencrypt,
+                encryption.unencrypt,
                 &encryption.password,
                 &format,
                 quiet,
+                exact,
             )?;
         }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -146,7 +146,7 @@ fn rename_alias_isolated_flow() -> Result<(), Box<dyn std::error::Error>> {
         .args(&["--password", PASSWORD])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Alias not found"));
+        .stderr(predicate::str::contains("No records found matching 'github'"));
 
     // collision Check: try to rename 'gh' to 'google' (exists)
     hermes(path)


### PR DESCRIPTION
Currently ls uses partial matching, causing ambiguous results when records share prefixes (e.g., 'google' and 'google2' both match 'google'). This makes scripting and pipeline usage unreliable.

Introduce --exact (-e) flag for strict alias matching:
ls --exact google   # returns only 'google', not 'google2'

Preserves backward compatibility—partial matching remains default behavior when flag is omitted.

Closes #59