### PR TITLE
fix(ui): handle terminal read_key error gracefully

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,8 +32,10 @@ impl<'a> Table<'a> {
         let flag_ref = flag.clone();
         let term_ref = output.clone();
         thread::spawn(move || {
-            term_ref.read_key().unwrap();
-            flag_ref.store(true, Ordering::Relaxed);
+            // If terminal is non-interactive, exit thread silently
+            if term_ref.read_key().is_ok() {
+                flag_ref.store(true, Ordering::Relaxed);
+            }
         });
 
         let mut rem = otp::get_remaining_seconds();


### PR DESCRIPTION
## Description

This PR ensures that the background key-reading thread handles non-interactive terminals safely instead of panicking. 
Previously, `term_ref.read_key().unwrap()` would cause the thread to crash if standard input was unavailable (e.g., in non-interactive CI/CD environments or cron jobs). This has been replaced with an idiomatic, safe `.is_ok()` check.

## Changes

* **Robustness:** Removed `.unwrap()` on `read_key()` to prevent background thread panics.
* **Graceful Exit:** If `read_key()` fails, the thread now exits silently without modifying the shutdown flag.
* **Code Quality:** Used the idiomatic Rust `.is_ok()` pattern rather than converting the result to an option.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring (idiomatic improvements)

## Checklist

- [x] `cargo fmt` executed (code style is clean)
- [x] `cargo check` passes without warnings
- [x] `cargo test` passes successfully
- [x] `cargo build` completes successfully
- [x] Manual testing completed (verified interactive keypress registers correctly and non-interactive environments exit safely)