### PR TITLE
fix(ui): replace f64::INFINITY cast with usize::MAX

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -74,7 +74,7 @@ impl<'a> Drop for Table<'a> {
         // Safe exit (also works in case of panic)
         let term = Term::stdout();
         term.show_cursor().unwrap();
-        term.move_cursor_down(f64::INFINITY as usize).unwrap();
+        term.move_cursor_down(usize::MAX).unwrap();
         term.clear_last_lines(1).unwrap() // Clear "press any key to exit" line
     }
 }


### PR DESCRIPTION
- casting f64::INFINITY to usize is implementation-defined behavior
- use portable usize::MAX instead