### PR TITLE
chore: apply clippy suggestions for paths, closures, and casts

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -5,7 +5,7 @@ use crate::otp;
 use crate::ui::Table;
 use data_encoding::BASE32_NOPAD;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 fn sanitize_and_validate_code(code: &str) -> Result<String, String> {
     let clean = code.to_uppercase().replace("=", "");
@@ -281,21 +281,20 @@ fn print_json(records: &[&Record], pass: &str, rem: u64) {
     println!("{}", serde_json::to_string_pretty(&list).unwrap());
 }
 
-pub fn migrate(path: &PathBuf) -> io::Result<()> {
+pub fn migrate(path: &Path) -> io::Result<()> {
     // create backup
     let backup_path = file::create_snapshot_backup(path)?;
     println!("Backup created at {:?}", backup_path);
 
     // read and parse everything using the hybrid parser
-    let records =
-        file::read_legacy_raw(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let records = file::read_legacy_raw(path).map_err(io::Error::other)?;
 
     // Serialize to JSON format
     let migrated_records: Vec<String> = records
         .iter()
         .map(serde_json::to_string)
         .collect::<Result<Vec<String>, serde_json::Error>>()
-        .map_err(|e| io::Error::other(e))?;
+        .map_err(io::Error::other)?;
 
     let count = migrated_records.len();
     let new_content = migrated_records.join("\n") + "\n";
@@ -307,7 +306,7 @@ pub fn migrate(path: &PathBuf) -> io::Result<()> {
     Ok(())
 }
 
-pub fn rename(path: &PathBuf, old_alias: &str, new_alias: &str) -> Result<(), String> {
+pub fn rename(path: &Path, old_alias: &str, new_alias: &str) -> Result<(), String> {
     // for Legacy file format
     if new_alias.contains(':') {
         return Err("The new alias cannot contain ':'".to_string());

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,4 @@
 use crate::models::Record;
-use dirs;
 use serde_json::Deserializer;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
@@ -111,7 +110,7 @@ pub fn read_legacy_raw(path: &Path) -> Result<Vec<Record>, String> {
 
     let records: Vec<Record> = content
         .lines()
-        .filter_map(|line| Record::from_legacy_line(line))
+        .filter_map(Record::from_legacy_line)
         .collect();
 
     if records.is_empty() && !content.trim().is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn resolve_codex_path(cli: &Cli) -> PathBuf {
     cli.path
         .clone()
         .or_else(|| std::env::var("HERMES_PATH").ok().map(PathBuf::from))
-        .unwrap_or_else(|| file::get_default_path())
+        .unwrap_or_else(file::get_default_path)
 }
 
 fn run(command: Commands, codex_path: PathBuf) -> Result<(), String> {

--- a/src/otp.rs
+++ b/src/otp.rs
@@ -20,7 +20,7 @@ fn get_current_timestamp() -> Result<u64, OtpError> {
 pub fn get_remaining_seconds() -> u64 {
     let now = get_current_timestamp().unwrap_or(0);
     // DEFAULT_STEP == 30s
-    DEFAULT_STEP as u64 - (now % DEFAULT_STEP as u64)
+    DEFAULT_STEP - (now % DEFAULT_STEP)
 }
 
 /*


### PR DESCRIPTION
- Change `&PathBuf` to `&Path` in `migrate` and `rename` signatures to avoid unnecessary allocations.
- Simplify `io::Error::new(io::ErrorKind::Other, ...)` to `io::Error::other`.
- Remove redundant closures in iterator chains and lazy unwraps.
- Remove unnecessary `u64` type casting on `DEFAULT_STEP`.
- Remove unused `dirs` import from `src/file.rs`.