### PR TITLE
ci: remove clippy and tests from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,6 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: ${{ matrix.target }}
-        components: clippy
-
-    - name: Run Clippy
-      run: cargo clippy --all-targets -- -D warnings
-
-    - name: Run Tests
-      if: contains(matrix.target, 'x86_64')
-      run: cargo test --release
 
     - name: Build
       run: cargo build --release --target ${{ matrix.target }} --locked


### PR DESCRIPTION
- CI already runs clippy, fmt, tests on every PR/push
- release.yml now only builds, strips, compresses, and uploads
- reduces release time by ~4-8 min (4 platforms x 2 checks)